### PR TITLE
Fix ocamlc no longer available on some systems

### DIFF
--- a/nix-opam-switch
+++ b/nix-opam-switch
@@ -91,6 +91,9 @@ case "$cmd" in
     prefix=$(opam var --switch "$switch_name" prefix)
     # Copy the compiler and tools into the created switch
     cp -rd --no-preserve=mode -T "$out" "$prefix"
+    # Hack: Symlinks interfere with Opam's system package integrity check
+    cp -L --remove-destination "$out/bin/ocamlc"{,.opt} "$prefix/bin/"
+    chmod +x "$prefix/bin/ocamlc"{,.opt}
     # Register a GC root to keep $out from being garbage collected
     nix-store --add-root "$prefix/nix-roots/switch" -r "$out" >/dev/null
     ;;


### PR DESCRIPTION
Fix https://github.com/Julow/nix-opam-switch/issues/2

Opam compares the location of `ocamlc` and `ocamlc.opt` to check integrity.
It seems that on some systems, symlink resolution is slightly different, making this check fail, even though `ocamlc` and `ocamlc.opt` are still available.